### PR TITLE
Switch to OpenAI GPT-5 mini model

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ pip install -e .
 Create a `.env` file in the project root with the following API keys:
 
 ```bash
-# LLM Provider (OpenRouter recommended)
-OPENROUTER_API_KEY=your_openrouter_api_key_here
-OPENROUTER_DEEPSEEK_R1=deepseek/deepseek-r1:free
-OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# LLM Provider (OpenAI GPT-5 mini)
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_GPT_5_MINI=gpt-5-mini
+OPENAI_BASE_URL=https://api.openai.com/v1
 
 # Data Providers
 TWELVE_API_KEY=your_twelvedata_api_key_here
@@ -110,7 +110,7 @@ RAPID_API_KEY=your_rapidapi_key_here
 
 ### 🔑 How to Get API Keys (All Have Free Tiers):
 
-1. **OpenRouter** (Free LLMs): [openrouter.ai](https://openrouter.ai) - Get free access to DeepSeek R1
+1. **OpenAI** (GPT-5 mini): [openai.com](https://platform.openai.com)
 2. **TwelveData** (Financial Data): [twelvedata.com](https://twelvedata.com) - Free tier available
 3. **Nixtla TimeGPT** (Forecasting): [nixtla.io](https://nixtla.io) - AI forecasting API
 4. **RapidAPI** (Social Data): [rapidapi.com](https://rapidapi.com) - For StockTwits sentiment data

--- a/ai_trading_crew/config.py
+++ b/ai_trading_crew/config.py
@@ -16,7 +16,7 @@ warnings.filterwarnings(
 
 
 # Valid LLM providers
-VALID_PROVIDERS = ["OPENROUTER"]
+VALID_PROVIDERS = ["OPENROUTER", "OPENAI"]
 
 BASE_SYMBOLS = ["AAPL", "NVDA", "MSFT", "AMZN", "GLD", "GOOGL", "TSLA"]
 
@@ -144,12 +144,12 @@ def extract_provider_name(model_name: str) -> str:
     raise ValueError(f"Model name '{model_name}' does not start with a valid provider: {', '.join(VALID_PROVIDERS)}")
 
 
-#OpenRouter DeepSeek R1 is used for all LLM operations in the system
+# OpenAI GPT-5 mini is used for all LLM operations in the system
 
-DEFAULT_PROJECT_LLM = "OPENROUTER_DEEPSEEK_R1"
-DEFAULT_STOCKTWITS_LLM = create_default_llm("OPENROUTER_API_KEY", "OPENROUTER_DEEPSEEK_R1", "OPENROUTER_BASE_URL")
-DEFAULT_TI_LLM = create_default_llm("OPENROUTER_API_KEY", "OPENROUTER_DEEPSEEK_R1", "OPENROUTER_BASE_URL")
-DEEPSEEK_OPENROUTER_LLM = create_default_llm("OPENROUTER_API_KEY", "OPENROUTER_DEEPSEEK_R1", "OPENROUTER_BASE_URL")
+DEFAULT_PROJECT_LLM = "OPENAI_GPT_5_MINI"
+DEFAULT_STOCKTWITS_LLM = create_default_llm("OPENAI_API_KEY", "OPENAI_GPT_5_MINI", "OPENAI_BASE_URL")
+DEFAULT_TI_LLM = create_default_llm("OPENAI_API_KEY", "OPENAI_GPT_5_MINI", "OPENAI_BASE_URL")
+OPENAI_GPT_5_MINI_LLM = create_default_llm("OPENAI_API_KEY", "OPENAI_GPT_5_MINI", "OPENAI_BASE_URL")
 
 
 OUTPUT_FOLDER  = "output"

--- a/ai_trading_crew/crew.py
+++ b/ai_trading_crew/crew.py
@@ -2,7 +2,17 @@ from crewai import Agent, Crew, Process, Task
 from crewai.project import CrewBase, agent, crew, task
 import os
 import yaml
-from ai_trading_crew.config import settings, DEFAULT_STOCKTWITS_LLM, PROJECT_LLM, DEFAULT_TI_LLM, DEEPSEEK_OPENROUTER_LLM, AGENT_OUTPUTS_FOLDER, AGENT_INPUTS_FOLDER, RELEVANT_ARTICLES_FILE, LOG_FOLDER
+from ai_trading_crew.config import (
+    settings,
+    DEFAULT_STOCKTWITS_LLM,
+    PROJECT_LLM,
+    DEFAULT_TI_LLM,
+    OPENAI_GPT_5_MINI_LLM,
+    AGENT_OUTPUTS_FOLDER,
+    AGENT_INPUTS_FOLDER,
+    RELEVANT_ARTICLES_FILE,
+    LOG_FOLDER,
+)
 from ai_trading_crew.utils.dates import get_today_str, get_yesterday_str, get_today_str_no_min
 import inspect
 
@@ -48,7 +58,7 @@ class AiArticlesPickerCrew(BaseCrewClass):
 		return Agent(
 			config=self.agents_config['relevant_news_filter_agent'],
 			verbose=True,
-			llm=DEEPSEEK_OPENROUTER_LLM
+                        llm=OPENAI_GPT_5_MINI_LLM
 		)
 
 	@task  # UN-commented but kept inactive through crew configuration
@@ -90,7 +100,7 @@ class StockComponentsSummarizeCrew(BaseCrewClass):
 		return Agent(
 			config=self.agents_config['news_summarizer_agent'],
 			verbose=True,
-			llm=DEEPSEEK_OPENROUTER_LLM
+                        llm=OPENAI_GPT_5_MINI_LLM
 		)
 
 	@agent  # UN-commented but kept inactive through crew configuration
@@ -228,7 +238,7 @@ class DayTraderAdvisorCrew:
 		return Agent(
 			config=self.agents_config['day_trader_advisor_agent'],
 			verbose=True,
-			llm=DEEPSEEK_OPENROUTER_LLM
+                        llm=OPENAI_GPT_5_MINI_LLM
 		)
 
 	def day_trader_recommendation_task(self) -> Task:


### PR DESCRIPTION
## Summary
- allow `OPENAI` as a valid LLM provider and configure GPT-5 mini as the default model
- update crew agents to use the new `OPENAI_GPT_5_MINI_LLM`
- document required OpenAI environment variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b20a688a5c832fbd2e2a5beef4a86b